### PR TITLE
Add PostgreSQL item API with QR codes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+PORT=3000
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=postgres
+DB_PASSWORD=yourpassword
+DB_NAME=garment_inventory

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ A scalable, cloud-based database system for managing garment samples using Fireb
    # Server configuration
    PORT=3000
 
+   # PostgreSQL configuration
+   DB_HOST=localhost
+   DB_PORT=5432
+   DB_USER=postgres
+   DB_PASSWORD=yourpassword
+   DB_NAME=garment_inventory
+
    # Firebase configuration
    FIREBASE_API_KEY=your_api_key
    FIREBASE_AUTH_DOMAIN=your_auth_domain
@@ -61,6 +68,10 @@ A scalable, cloud-based database system for managing garment samples using Fireb
    ```
    npm run dev
    ```
+5. Create the PostgreSQL table:
+   ```
+   psql -d garment_inventory -f sql/create_items_table.sql
+   ```
 
 ## API Endpoints
 
@@ -73,6 +84,16 @@ A scalable, cloud-based database system for managing garment samples using Fireb
 | POST   | /api/samples | Create a new sample |
 | PUT    | /api/samples/:styleId | Update a sample |
 | DELETE | /api/samples/:styleId | Delete a sample |
+
+### Items (PostgreSQL)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET    | /api/items | Get all garments |
+| GET    | /api/items/:id | Get item by ID |
+| POST   | /api/items | Create a new garment and QR code |
+| PUT    | /api/items/:id | Update an item |
+| DELETE | /api/items/:id | Delete an item |
 
 ### Sample API Requests
 
@@ -108,6 +129,22 @@ GET /api/samples/ABC123
 A Postman collection is included in the repository (`postman_collection.json`). Import this collection into Postman to test the API endpoints.
 
 ## Data Schema
+
+### items table (PostgreSQL)
+
+```
+id SERIAL PRIMARY KEY
+style_code VARCHAR
+price NUMERIC
+quantity INTEGER
+color VARCHAR
+fabric_composition VARCHAR
+fabric_weight NUMERIC
+packaging_details TEXT
+qr_code_url TEXT
+image_url TEXT
+created_at TIMESTAMP DEFAULT NOW()
+```
 
 Each document in the `samples` collection represents a garment sample with the following fields:
 

--- a/client/package.json
+++ b/client/package.json
@@ -27,6 +27,8 @@
     "next": "^14.1.0",
     "postcss": "^8.4.32",
     "qrcode.react": "^3.1.0",
+    "html5-qrcode": "^2.3.9",
+    "xlsx": "^0.18.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.11.2",

--- a/client/src/api/itemApi.js
+++ b/client/src/api/itemApi.js
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || '/api';
+const api = axios.create({ baseURL: API_URL, headers: { 'Content-Type': 'application/json' } });
+
+const itemApi = {
+  getAll: async () => (await api.get('/items')).data,
+  getById: async (id) => (await api.get(`/items/${id}`)).data,
+  create: async (data) => (await api.post('/items', data)).data,
+  update: async (id, data) => (await api.put(`/items/${id}`, data)).data,
+  remove: async (id) => (await api.delete(`/items/${id}`)).data,
+};
+
+export default itemApi;

--- a/client/src/pages/item-scanner.jsx
+++ b/client/src/pages/item-scanner.jsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from 'react';
+import { Html5QrcodeScanner } from 'html5-qrcode';
+import itemApi from '../api/itemApi';
+import * as XLSX from 'xlsx';
+
+export default function ItemScanner() {
+  const [item, setItem] = useState(null);
+  const scannerRef = useRef(null);
+
+  useEffect(() => {
+    const scanner = new Html5QrcodeScanner('qr-reader', { fps: 10, qrbox: 250 });
+    scanner.render(async (text) => {
+      scanner.clear();
+      const id = text.split('/').pop();
+      const data = await itemApi.getById(id);
+      setItem(data);
+    });
+    scannerRef.current = scanner;
+    return () => {
+      scanner.clear().catch(() => {});
+    };
+  }, []);
+
+  const exportCsv = () => {
+    if (!item) return;
+    const ws = XLSX.utils.json_to_sheet([item]);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Item');
+    XLSX.writeFile(wb, 'item.csv');
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Scan Item QR</h1>
+      <div id="qr-reader" className="mb-4" />
+      {item && (
+        <div>
+          <table className="table-auto border mb-4">
+            <tbody>
+              <tr><th className="px-2">Style Code</th><td className="px-2">{item.style_code}</td></tr>
+              <tr><th className="px-2">Price</th><td className="px-2">{item.price}</td></tr>
+              <tr><th className="px-2">Quantity</th><td className="px-2">{item.quantity}</td></tr>
+              <tr><th className="px-2">Color</th><td className="px-2">{item.color}</td></tr>
+              <tr><th className="px-2">Fabric Weight</th><td className="px-2">{item.fabric_weight}</td></tr>
+              <tr><th className="px-2">Fabric Composition</th><td className="px-2">{item.fabric_composition}</td></tr>
+              <tr><th className="px-2">Packaging</th><td className="px-2">{item.packaging_details}</td></tr>
+              <tr><th className="px-2">QR Code</th><td className="px-2"><img src={`/${item.qr_code_url}`} alt="qr" width="100" /></td></tr>
+            </tbody>
+          </table>
+          <button onClick={exportCsv} className="bg-blue-500 text-white px-3 py-1">Export CSV</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/items.js
+++ b/client/src/pages/items.js
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import itemApi from '../api/itemApi';
+
+export default function Items() {
+  const [items, setItems] = useState([]);
+  useEffect(() => { itemApi.getAll().then(setItems); }, []);
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Items</h1>
+      <table className="table-auto border">
+        <thead>
+          <tr>
+            <th className="px-2">Style Code</th>
+            <th className="px-2">Price</th>
+            <th className="px-2">Quantity</th>
+            <th className="px-2">Color</th>
+            <th className="px-2">QR</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map(it => (
+            <tr key={it.id}>
+              <td className="px-2">{it.style_code}</td>
+              <td className="px-2">{it.price}</td>
+              <td className="px-2">{it.quantity}</td>
+              <td className="px-2">{it.color}</td>
+              <td className="px-2"><img src={`/${it.qr_code_url}`} alt="qr" width="50"/></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -33,9 +33,14 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "body-parser": "^1.20.2",
     "firebase": "^10.8.0",
+    "multer": "^1.4.5-lts.1",
     "http-status-codes": "^2.3.0",
-    "joi": "^17.11.0"
+    "joi": "^17.11.0",
+    "pg": "^8.11.1",
+    "qrcode": "^1.5.3",
+    "csv-parser": "^3.0.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/sql/create_items_table.sql
+++ b/sql/create_items_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS items (
+  id SERIAL PRIMARY KEY,
+  style_code VARCHAR,
+  price NUMERIC,
+  quantity INTEGER,
+  color VARCHAR,
+  fabric_composition VARCHAR,
+  fabric_weight NUMERIC,
+  packaging_details TEXT,
+  qr_code_url TEXT,
+  image_url TEXT,
+  created_at TIMESTAMP DEFAULT NOW()
+);

--- a/src/api/routes/itemRoutes.js
+++ b/src/api/routes/itemRoutes.js
@@ -1,0 +1,121 @@
+import express from 'express';
+import multer from 'multer';
+import path from 'path';
+import fs from 'fs';
+import pool from '../../config/postgres.js';
+import QRCode from 'qrcode';
+
+const router = express.Router();
+const upload = multer({ dest: 'uploads/' });
+
+// GET all items
+router.get('/', async (req, res) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM items ORDER BY created_at DESC');
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+// GET single item by id
+router.get('/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { rows } = await pool.query('SELECT * FROM items WHERE id = $1', [id]);
+    if (rows.length === 0) return res.status(404).json({ error: 'Not found' });
+    res.json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+// POST create item with optional image
+router.post('/', upload.single('image'), async (req, res) => {
+  try {
+    const { style_code, price, quantity, color, fabric_composition, fabric_weight, packaging_details } = req.body;
+    const imagePath = req.file ? req.file.path : null;
+    const insertQuery = `INSERT INTO items (style_code, price, quantity, color, fabric_composition, fabric_weight, packaging_details, image_url)
+                         VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING *`;
+    const values = [style_code, price, quantity, color, fabric_composition, fabric_weight, packaging_details, imagePath];
+    const { rows } = await pool.query(insertQuery, values);
+    const item = rows[0];
+
+    const qrPath = path.join('qr-codes', `item-${item.id}.png`);
+    await fs.promises.mkdir('qr-codes', { recursive: true });
+    await QRCode.toFile(qrPath, `https://mydomain.com/item/${item.id}`);
+    await pool.query('UPDATE items SET qr_code_url=$1 WHERE id=$2', [qrPath, item.id]);
+
+    const qrData = await fs.promises.readFile(qrPath);
+    const base64Qr = qrData.toString('base64');
+    res.status(201).json({ ...item, qr_code_url: qrPath, qr_code_base64: base64Qr });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+// PUT update item
+router.put('/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const fields = ['price','quantity','color','fabric_composition','fabric_weight','packaging_details'];
+    const updates = [];
+    const values = [];
+    fields.forEach((field, idx) => {
+      if (req.body[field] !== undefined) {
+        updates.push(`${field}=$${values.length+1}`);
+        values.push(req.body[field]);
+      }
+    });
+    if (updates.length === 0) return res.status(400).json({ error: 'No valid fields' });
+    values.push(id);
+    const query = `UPDATE items SET ${updates.join(', ')} WHERE id=$${values.length} RETURNING *`;
+    const { rows } = await pool.query(query, values);
+    if (rows.length === 0) return res.status(404).json({ error: 'Not found' });
+    res.json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+// DELETE item
+router.delete('/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { rows } = await pool.query('DELETE FROM items WHERE id=$1 RETURNING *', [id]);
+    if (rows.length === 0) return res.status(404).json({ error: 'Not found' });
+    // delete QR code file if exists
+    if (rows[0].qr_code_url) {
+      fs.unlink(rows[0].qr_code_url, () => {});
+    }
+    res.json({ message: 'Deleted' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+// Summary report
+router.get('/reports/summary', async (req, res) => {
+  try {
+    const countResult = await pool.query('SELECT COUNT(*) FROM items');
+    const valueResult = await pool.query('SELECT SUM(price * quantity) AS total FROM items');
+    const fabricResult = await pool.query('SELECT fabric_composition, COUNT(*) FROM items GROUP BY fabric_composition');
+    const colorResult = await pool.query('SELECT color, COUNT(*) FROM items GROUP BY color');
+    res.json({
+      total_items: parseInt(countResult.rows[0].count, 10),
+      total_value: Number(valueResult.rows[0].total || 0),
+      by_fabric: fabricResult.rows,
+      by_color: colorResult.rows,
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+export default router;

--- a/src/config/postgres.js
+++ b/src/config/postgres.js
@@ -1,0 +1,13 @@
+import { Pool } from 'pg';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const pool = new Pool({
+  host: process.env.DB_HOST,
+  port: process.env.DB_PORT,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME || 'garment_inventory',
+});
+
+export default pool;

--- a/src/server.js
+++ b/src/server.js
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import sampleRoutes from './api/routes/sampleRoutes.js';
+import itemRoutes from './api/routes/itemRoutes.js';
 import { errorHandler, notFound } from './api/middleware/errorHandler.js';
 
 // Load environment variables
@@ -26,9 +27,12 @@ app.use((req, res, next) => {
 // Increase JSON payload limit for image data
 app.use(express.json({ limit: '50mb' }));
 app.use(express.urlencoded({ extended: true, limit: '50mb' }));
+app.use('/qr-codes', express.static('qr-codes'));
+app.use('/uploads', express.static('uploads'));
 
 // API Routes
 app.use('/api/samples', sampleRoutes);
+app.use('/api/items', itemRoutes);
 
 // Root route
 app.get('/', (req, res) => {


### PR DESCRIPTION
## Summary
- add PostgreSQL connection configuration
- add Express router for item CRUD and reports with QR code generation
- serve `/qr-codes` and `/uploads` directories
- document PostgreSQL setup and API endpoints
- provide example env file
- add React pages for viewing items and scanning QR codes

## Testing
- `npm install --package-lock-only` *(fails: 403 Forbidden)*
- `npm test` *(fails: Cannot find package 'firebase')*


------
https://chatgpt.com/codex/tasks/task_e_684922e574dc832e9c04e734ee348a72